### PR TITLE
fix: Update README with docker login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Screwdriver in a Box
 
-This handy feature will bring up an entire Screwdriver instance (ui, api, and log store) locally
+This handy feature will bring up an entire Screwdriver instance (UI, API, and log store) locally
 for you to play with.  All data written to a database will be stored in `data` directory.
 
 Requires:
@@ -8,16 +8,16 @@ Requires:
  - [Docker][docker]
  - [Docker Compose 1.8.1+][docker-compose]
 
-
-Run the below command in your terminal to bring up a Screwdriver cluster locally.
+1. [Login to Docker](https://docs.docker.com/engine/reference/commandline/login).
+2. Run the below command in your terminal to bring up a Screwdriver cluster locally.
 
 ```bash
 $ python <(curl -L https://git.io/screwdriver-box)
 ```
-You will be prompted to enter your desired SCM provider as well as your Client ID and Client Secret. Afterwards, type `y` to launch Screwdriver!
-
+3. You will be prompted to enter your desired SCM provider as well as your Client ID and Client Secret. Afterwards, type `y` to launch Screwdriver!
 
 For further documentation please see: https://docs.screwdriver.cd/cluster-management/running-locally
+
 To set up your own cluster, see: https://docs.screwdriver.cd/cluster-management/kubernetes
 
 [docker-compose]: https://www.docker.com/products/docker-compose

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Requires:
  - [Docker][docker]
  - [Docker Compose 1.8.1+][docker-compose]
 
-1. [Login to Docker](https://docs.docker.com/engine/reference/commandline/login).
+1. [Login to Docker](https://docs.docker.com/engine/reference/commandline/login) with your Docker username (not email).
 2. Run the below command in your terminal to bring up a Screwdriver cluster locally.
 
 ```bash


### PR DESCRIPTION
Add instruction to login to docker with username.

Users might run into this issue otherwise:
```
[~]$ docker-compose -p screwdriver up
Pulling api (screwdrivercd/screwdriver:stable)...
ERROR: Get https://registry-1.docker.io/v2/screwdrivercd/screwdriver/manifests/stable: unauthorized: incorrect username or password
```
https://forums.docker.com/t/unauthorized-incorrect-username-or-password/35677/5