### PR TITLE
Fix docker path detection: add tilde expansion in PATH

### DIFF
--- a/package/screwdriver_cd_setup/__init__.py
+++ b/package/screwdriver_cd_setup/__init__.py
@@ -240,7 +240,12 @@ def check_component(component):
     """
     Search for a component executable and exit if not found
     """
-    if shutil.which(component) is None:
+    # Expand tildes in PATH since shutil.which doesn't do this automatically
+    path = os.environ.get('PATH', os.defpath)
+    expanded_path = os.pathsep.join(
+        os.path.expanduser(p) for p in path.split(os.pathsep)
+    )
+    if shutil.which(component, path=expanded_path) is None:
         print(
             '💀   Could not find {0}, please install and set path to '
             '{0}'.format(component)

--- a/package/screwdriver_cd_setup/__init__.py
+++ b/package/screwdriver_cd_setup/__init__.py
@@ -236,16 +236,34 @@ def generate_scm_config(scm_plugin, ip): # pylint: disable=C0103
     return dict(scm_config=json.dumps(scm_config), avatar=avatar)
 
 
+def get_expanded_path():
+    """
+    Get PATH with tildes expanded to full paths.
+    This is needed because Rancher Desktop and similar tools may add
+    paths like ~/.rd/bin to PATH, but subprocess won't expand the tilde.
+    """
+    path = os.environ.get('PATH', os.defpath)
+    return os.pathsep.join(
+        os.path.expanduser(p) for p in path.split(os.pathsep)
+    )
+
+
+def get_expanded_env():
+    """
+    Get a copy of the environment with PATH expanded.
+    Use this when calling subprocess functions to ensure executables
+    in paths like ~/.rd/bin can be found.
+    """
+    env = os.environ.copy()
+    env['PATH'] = get_expanded_path()
+    return env
+
+
 def check_component(component):
     """
     Search for a component executable and exit if not found
     """
-    # Expand tildes in PATH since shutil.which doesn't do this automatically
-    path = os.environ.get('PATH', os.defpath)
-    expanded_path = os.pathsep.join(
-        os.path.expanduser(p) for p in path.split(os.pathsep)
-    )
-    if shutil.which(component, path=expanded_path) is None:
+    if shutil.which(component, path=get_expanded_path()) is None:
         print(
             '💀   Could not find {0}, please install and set path to '
             '{0}'.format(component)
@@ -291,9 +309,10 @@ def main():
     )
     prompt = get_input('    Would you like to run them now? (y/n) ')
     if prompt.lower() == 'y':
-        call(['docker', 'pull', 'screwdrivercd/launcher:stable'])
-        call(['docker-compose', 'pull'])
-        call(['docker-compose', '-p', 'screwdriver', 'up', '-d'])
+        env = get_expanded_env()
+        call(['docker', 'pull', 'screwdrivercd/launcher:stable'], env=env)
+        call(['docker-compose', 'pull'], env=env)
+        call(['docker-compose', '-p', 'screwdriver', 'up', '-d'], env=env)
         try:
             call(['open', Template('http://${ip}:9000').safe_substitute(fields)])
         except (CalledProcessError, FileNotFoundError):

--- a/package/screwdriver_cd_setup/__init__.py
+++ b/package/screwdriver_cd_setup/__init__.py
@@ -7,9 +7,9 @@ from __future__ import print_function
 import getpass
 import json
 import os
+import shutil
 import socket
 import sys
-import distutils.spawn
 from string import Template
 from subprocess import check_output, call, STDOUT, CalledProcessError
 try:
@@ -240,7 +240,7 @@ def check_component(component):
     """
     Search for a component executable and exit if not found
     """
-    if distutils.spawn.find_executable(component) is None:
+    if shutil.which(component) is None:
         print(
             '💀   Could not find {0}, please install and set path to '
             '{0}'.format(component)


### PR DESCRIPTION
## Context

I could not get the installation script to work on my machine.

I tried to install Screwdriver on my macbook following the Getting Started guide on https://screwdriver.cd/ and it didn't work, it didn't find my Rancher Desktop docker:

```
$ python <(curl -L https://tinyurl.com/sd-in-a-box)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   674    0   674    0     0   2196      0 --:--:-- --:--:-- --:--:--  2202
100  9508  100  9508    0     0  16595      0 --:--:-- --:--:-- --:--:-- 16595
🎁   Boxing up Screwdriver
👀   Checking prerequisites
/dev/fd/63:243: DeprecationWarning: Use shutil.which instead of find_executable
💀   Could not find docker, please install and set path to docker
$ type docker
docker is hashed (/Users/atsalolikhin/.rd/bin/docker)
$
```

Added two helper functions:
  - get_expanded_path() - returns PATH with all tildes expanded
  - get_expanded_env() - returns a copy of the environment with the expanded PATH

Now the docker and docker-compose calls pass `env=get_expanded_env()` so they can find executables in `~/.rd/bin` (rd being Rancher Desktop).

After making these changes I was able to start Screwdriver and login to my local instance.

### Incidental fix

Change deprecated `distutils.spawn` to modern `shutil`.



## Objective

This PR upgrades the python library to a modern one and adds user path expansion because my path has ~ in it: `~/.rd/bin`.

## References

Warning:  `DeprecationWarning: Use shutil.which instead of find_executable`

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.